### PR TITLE
feat: use grouped keywords

### DIFF
--- a/src/scripts/update-grammar.ts
+++ b/src/scripts/update-grammar.ts
@@ -5,7 +5,7 @@ import plist = require('fast-plist');
 const tsGrammarPlist = fs.readFileSync('./grammar/TypeScript.tmLanguage');
 const tsGrammarJSON = plist.parse(tsGrammarPlist.toString('utf8'));
 const mongodbGrammar = path.resolve('./syntaxes/mongodb.tmLanguage.json');
-let mongodbSymbols = require(path.resolve('./syntaxes/mongodb-symbols.json'));
+const mongodbSymbols = require(path.resolve('./syntaxes/mongodb-symbols.json'));
 
 /**
  * Updates `.ts` rule names to `.mongodb`.
@@ -72,27 +72,20 @@ const mongoDBGrammarJSON = {
   repository
 };
 
-// Get all MongoDB symbols as a single array
-mongodbSymbols = Object.values(mongodbSymbols);
-mongodbSymbols = (mongodbSymbols as any[]).reduce(
-  (acc, val) => acc.concat(val),
-  []
-);
-// Create an array of unique values
-// [...new Set()] is equal to `lodash.union`
-mongodbSymbols = [...new Set(mongodbSymbols)];
-// Inject MongoDB symbols into the grammar
-mongodbSymbols.forEach((item) => {
-  const value = item.substring(1);
+// Inject the resulting grammar with MongoDB symbols
+Object.keys(mongodbSymbols).forEach((key) => {
+  mongodbSymbols[key].forEach((item) => {
+    const value = item.substring(1);
 
-  mongoDBGrammarJSON.repository['object-member'].patterns.unshift({
-    name: 'meta.object.member.mongodb',
-    match: `\\$${value}\\b`,
-    captures: {
-      0: {
-        name: `keyword.${value}.mongodb`
+    mongoDBGrammarJSON.repository['object-member'].patterns.unshift({
+      name: 'meta.object.member.mongodb',
+      match: `\\$${value}\\b`,
+      captures: {
+        0: {
+          name: `keyword.other.${key}.${value}.mongodb`
+        }
       }
-    }
+    });
   });
 });
 

--- a/syntaxes/mongodb.tmLanguage.json
+++ b/syntaxes/mongodb.tmLanguage.json
@@ -2556,7 +2556,7 @@
           "match": "\\$undefined\\b",
           "captures": {
             "0": {
-              "name": "keyword.undefined.mongodb"
+              "name": "keyword.other.aggBSON.undefined.mongodb"
             }
           }
         },
@@ -2565,7 +2565,7 @@
           "match": "\\$timestamp\\b",
           "captures": {
             "0": {
-              "name": "keyword.timestamp.mongodb"
+              "name": "keyword.other.aggBSON.timestamp.mongodb"
             }
           }
         },
@@ -2574,304 +2574,7 @@
           "match": "\\$regularExpression\\b",
           "captures": {
             "0": {
-              "name": "keyword.regularExpression.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$oid\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.oid.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$numberLong\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.numberLong.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$numberInt\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.numberInt.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$numberDouble\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.numberDouble.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$numberDecimal\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.numberDecimal.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$minKey\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.minKey.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$maxKey\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.maxKey.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$date\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.date.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$binary\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.binary.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$unwind\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.unwind.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$sortByCount\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.sortByCount.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$sort\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.sort.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$skip\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.skip.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$sample\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.sample.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$replaceRoot\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.replaceRoot.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$redact\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.redact.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$project\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.project.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$out\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.out.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$match\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.match.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$lookup\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.lookup.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$limit\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.limit.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$indexStats\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.indexStats.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$group\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.group.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$graphLookup\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.graphLookup.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$geoNear\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.geoNear.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$facet\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.facet.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$count\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.count.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$collStats\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.collStats.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$bucketAuto\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.bucketAuto.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$bucket\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.bucket.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$addFields\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.addFields.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$where\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.where.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$text\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.text.mongodb"
+              "name": "keyword.other.aggBSON.regularExpression.mongodb"
             }
           }
         },
@@ -2880,196 +2583,295 @@
           "match": "\\$regex\\b",
           "captures": {
             "0": {
-              "name": "keyword.regex.mongodb"
+              "name": "keyword.other.aggBSON.regex.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$nor\\b",
+          "match": "\\$oid\\b",
           "captures": {
             "0": {
-              "name": "keyword.nor.mongodb"
+              "name": "keyword.other.aggBSON.oid.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$nin\\b",
+          "match": "\\$numberLong\\b",
           "captures": {
             "0": {
-              "name": "keyword.nin.mongodb"
+              "name": "keyword.other.aggBSON.numberLong.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$nearSphere\\b",
+          "match": "\\$numberInt\\b",
           "captures": {
             "0": {
-              "name": "keyword.nearSphere.mongodb"
+              "name": "keyword.other.aggBSON.numberInt.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$near\\b",
+          "match": "\\$numberDouble\\b",
           "captures": {
             "0": {
-              "name": "keyword.near.mongodb"
+              "name": "keyword.other.aggBSON.numberDouble.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$ne\\b",
+          "match": "\\$numberDecimal\\b",
           "captures": {
             "0": {
-              "name": "keyword.ne.mongodb"
+              "name": "keyword.other.aggBSON.numberDecimal.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$lte\\b",
+          "match": "\\$minKey\\b",
           "captures": {
             "0": {
-              "name": "keyword.lte.mongodb"
+              "name": "keyword.other.aggBSON.minKey.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$jsonSchema\\b",
+          "match": "\\$maxKey\\b",
           "captures": {
             "0": {
-              "name": "keyword.jsonSchema.mongodb"
+              "name": "keyword.other.aggBSON.maxKey.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$geoWithin\\b",
+          "match": "\\$date\\b",
           "captures": {
             "0": {
-              "name": "keyword.geoWithin.mongodb"
+              "name": "keyword.other.aggBSON.date.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$geoIntersects\\b",
+          "match": "\\$binary\\b",
           "captures": {
             "0": {
-              "name": "keyword.geoIntersects.mongodb"
+              "name": "keyword.other.aggBSON.binary.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$expr\\b",
+          "match": "\\$unwind\\b",
           "captures": {
             "0": {
-              "name": "keyword.expr.mongodb"
+              "name": "keyword.other.aggStageOperators.unwind.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$exists\\b",
+          "match": "\\$sortByCount\\b",
           "captures": {
             "0": {
-              "name": "keyword.exists.mongodb"
+              "name": "keyword.other.aggStageOperators.sortByCount.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$elemMatch\\b",
+          "match": "\\$sort\\b",
           "captures": {
             "0": {
-              "name": "keyword.elemMatch.mongodb"
+              "name": "keyword.other.aggStageOperators.sort.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$comment\\b",
+          "match": "\\$skip\\b",
           "captures": {
             "0": {
-              "name": "keyword.comment.mongodb"
+              "name": "keyword.other.aggStageOperators.skip.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$bitsAnySet\\b",
+          "match": "\\$sample\\b",
           "captures": {
             "0": {
-              "name": "keyword.bitsAnySet.mongodb"
+              "name": "keyword.other.aggStageOperators.sample.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$bitsAnyClear\\b",
+          "match": "\\$replaceRoot\\b",
           "captures": {
             "0": {
-              "name": "keyword.bitsAnyClear.mongodb"
+              "name": "keyword.other.aggStageOperators.replaceRoot.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$bitsAllSet\\b",
+          "match": "\\$redact\\b",
           "captures": {
             "0": {
-              "name": "keyword.bitsAllSet.mongodb"
+              "name": "keyword.other.aggStageOperators.redact.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$bitsAllClear\\b",
+          "match": "\\$project\\b",
           "captures": {
             "0": {
-              "name": "keyword.bitsAllClear.mongodb"
+              "name": "keyword.other.aggStageOperators.project.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$all\\b",
+          "match": "\\$out\\b",
           "captures": {
             "0": {
-              "name": "keyword.all.mongodb"
+              "name": "keyword.other.aggStageOperators.out.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$zip\\b",
+          "match": "\\$match\\b",
           "captures": {
             "0": {
-              "name": "keyword.zip.mongodb"
+              "name": "keyword.other.aggStageOperators.match.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$year\\b",
+          "match": "\\$lookup\\b",
           "captures": {
             "0": {
-              "name": "keyword.year.mongodb"
+              "name": "keyword.other.aggStageOperators.lookup.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$week\\b",
+          "match": "\\$limit\\b",
           "captures": {
             "0": {
-              "name": "keyword.week.mongodb"
+              "name": "keyword.other.aggStageOperators.limit.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$indexStats\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.indexStats.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$group\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.group.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$graphLookup\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.graphLookup.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$geoNear\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.geoNear.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$facet\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.facet.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$count\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.count.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$collStats\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.collStats.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$bucketAuto\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.bucketAuto.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$bucket\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.bucket.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$addFields\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggStageOperators.addFields.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$where\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.QueryOperators.where.mongodb"
             }
           }
         },
@@ -3078,124 +2880,16 @@
           "match": "\\$type\\b",
           "captures": {
             "0": {
-              "name": "keyword.type.mongodb"
+              "name": "keyword.other.QueryOperators.type.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$trunc\\b",
+          "match": "\\$text\\b",
           "captures": {
             "0": {
-              "name": "keyword.trunc.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$toUpper\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.toUpper.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$toLower\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.toLower.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$switch\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.switch.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$subtract\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.subtract.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$substrCP\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.substrCP.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$substrBytes\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.substrBytes.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$substr\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.substr.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$strLenCP\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.strLenCP.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$strLenBytes\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.strLenBytes.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$strcasecmp\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.strcasecmp.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$sqrt\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.sqrt.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$split\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.split.mongodb"
+              "name": "keyword.other.QueryOperators.text.mongodb"
             }
           }
         },
@@ -3204,7 +2898,7 @@
           "match": "\\$slice\\b",
           "captures": {
             "0": {
-              "name": "keyword.slice.mongodb"
+              "name": "keyword.other.QueryOperators.slice.mongodb"
             }
           }
         },
@@ -3213,97 +2907,16 @@
           "match": "\\$size\\b",
           "captures": {
             "0": {
-              "name": "keyword.size.mongodb"
+              "name": "keyword.other.QueryOperators.size.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$setUnion\\b",
+          "match": "\\$regex\\b",
           "captures": {
             "0": {
-              "name": "keyword.setUnion.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$setIsSubset\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.setIsSubset.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$setIntersection\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.setIntersection.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$setEquals\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.setEquals.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$setDifference\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.setDifference.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$second\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.second.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$reverseArray\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.reverseArray.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$reduce\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.reduce.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$range\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.range.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$pow\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.pow.mongodb"
+              "name": "keyword.other.QueryOperators.regex.mongodb"
             }
           }
         },
@@ -3312,16 +2925,16 @@
           "match": "\\$or\\b",
           "captures": {
             "0": {
-              "name": "keyword.or.mongodb"
+              "name": "keyword.other.QueryOperators.or.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$objectToArray\\b",
+          "match": "\\$nor\\b",
           "captures": {
             "0": {
-              "name": "keyword.objectToArray.mongodb"
+              "name": "keyword.other.QueryOperators.nor.mongodb"
             }
           }
         },
@@ -3330,34 +2943,43 @@
           "match": "\\$not\\b",
           "captures": {
             "0": {
-              "name": "keyword.not.mongodb"
+              "name": "keyword.other.QueryOperators.not.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$new\\b",
+          "match": "\\$nin\\b",
           "captures": {
             "0": {
-              "name": "keyword.new.mongodb"
+              "name": "keyword.other.QueryOperators.nin.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$multiply\\b",
+          "match": "\\$nearSphere\\b",
           "captures": {
             "0": {
-              "name": "keyword.multiply.mongodb"
+              "name": "keyword.other.QueryOperators.nearSphere.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$month\\b",
+          "match": "\\$near\\b",
           "captures": {
             "0": {
-              "name": "keyword.month.mongodb"
+              "name": "keyword.other.QueryOperators.near.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$ne\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.QueryOperators.ne.mongodb"
             }
           }
         },
@@ -3366,79 +2988,16 @@
           "match": "\\$mod\\b",
           "captures": {
             "0": {
-              "name": "keyword.mod.mongodb"
+              "name": "keyword.other.QueryOperators.mod.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$minute\\b",
+          "match": "\\$lte\\b",
           "captures": {
             "0": {
-              "name": "keyword.minute.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$millisecond\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.millisecond.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$meta\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.meta.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$mergeObjects\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.mergeObjects.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$map\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.map.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$log10\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.log10.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$log\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.log.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$ln\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.ln.mongodb"
+              "name": "keyword.other.QueryOperators.lte.mongodb"
             }
           }
         },
@@ -3447,88 +3006,16 @@
           "match": "\\$lt\\b",
           "captures": {
             "0": {
-              "name": "keyword.lt.mongodb"
+              "name": "keyword.other.QueryOperators.lt.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$literal\\b",
+          "match": "\\$jsonSchema\\b",
           "captures": {
             "0": {
-              "name": "keyword.literal.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$let\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.let.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$isoWeekYear\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.isoWeekYear.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$isoWeek\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.isoWeek.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$isoDayOfWeek\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.isoDayOfWeek.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$isArray\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.isArray.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$indexOfCP\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.indexOfCP.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$indexOfBytes\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.indexOfBytes.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$indexOfArray\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.indexOfArray.mongodb"
+              "name": "keyword.other.QueryOperators.jsonSchema.mongodb"
             }
           }
         },
@@ -3537,25 +3024,7 @@
           "match": "\\$in\\b",
           "captures": {
             "0": {
-              "name": "keyword.in.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$ifNull\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.ifNull.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$hour\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.hour.mongodb"
+              "name": "keyword.other.QueryOperators.in.mongodb"
             }
           }
         },
@@ -3564,7 +3033,7 @@
           "match": "\\$gte\\b",
           "captures": {
             "0": {
-              "name": "keyword.gte.mongodb"
+              "name": "keyword.other.QueryOperators.gte.mongodb"
             }
           }
         },
@@ -3573,34 +3042,43 @@
           "match": "\\$gt\\b",
           "captures": {
             "0": {
-              "name": "keyword.gt.mongodb"
+              "name": "keyword.other.QueryOperators.gt.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$floor\\b",
+          "match": "\\$geoWithin\\b",
           "captures": {
             "0": {
-              "name": "keyword.floor.mongodb"
+              "name": "keyword.other.QueryOperators.geoWithin.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$filter\\b",
+          "match": "\\$geoIntersects\\b",
           "captures": {
             "0": {
-              "name": "keyword.filter.mongodb"
+              "name": "keyword.other.QueryOperators.geoIntersects.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$exp\\b",
+          "match": "\\$expr\\b",
           "captures": {
             "0": {
-              "name": "keyword.exp.mongodb"
+              "name": "keyword.other.QueryOperators.expr.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$exists\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.QueryOperators.exists.mongodb"
             }
           }
         },
@@ -3609,151 +3087,61 @@
           "match": "\\$eq\\b",
           "captures": {
             "0": {
-              "name": "keyword.eq.mongodb"
+              "name": "keyword.other.QueryOperators.eq.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$divide\\b",
+          "match": "\\$elemMatch\\b",
           "captures": {
             "0": {
-              "name": "keyword.divide.mongodb"
+              "name": "keyword.other.QueryOperators.elemMatch.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$dayOfYear\\b",
+          "match": "\\$comment\\b",
           "captures": {
             "0": {
-              "name": "keyword.dayOfYear.mongodb"
+              "name": "keyword.other.QueryOperators.comment.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$dayOfWeek\\b",
+          "match": "\\$bitsAnySet\\b",
           "captures": {
             "0": {
-              "name": "keyword.dayOfWeek.mongodb"
+              "name": "keyword.other.QueryOperators.bitsAnySet.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$dayOfMonth\\b",
+          "match": "\\$bitsAnyClear\\b",
           "captures": {
             "0": {
-              "name": "keyword.dayOfMonth.mongodb"
+              "name": "keyword.other.QueryOperators.bitsAnyClear.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$dateToString\\b",
+          "match": "\\$bitsAllSet\\b",
           "captures": {
             "0": {
-              "name": "keyword.dateToString.mongodb"
+              "name": "keyword.other.QueryOperators.bitsAllSet.mongodb"
             }
           }
         },
         {
           "name": "meta.object.member.mongodb",
-          "match": "\\$dateToParts\\b",
+          "match": "\\$bitsAllClear\\b",
           "captures": {
             "0": {
-              "name": "keyword.dateToParts.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$dateFromString\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.dateFromString.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$dateFromParts\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.dateFromParts.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$cond\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.cond.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$concatArrays\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.concatArrays.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$concat\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.concat.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$cmp\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.cmp.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$ceil\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.ceil.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$arrayToObject\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.arrayToObject.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$arrayElemAt\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.arrayElemAt.mongodb"
-            }
-          }
-        },
-        {
-          "name": "meta.object.member.mongodb",
-          "match": "\\$anyElementTrue\\b",
-          "captures": {
-            "0": {
-              "name": "keyword.anyElementTrue.mongodb"
+              "name": "keyword.other.QueryOperators.bitsAllClear.mongodb"
             }
           }
         },
@@ -3762,7 +3150,736 @@
           "match": "\\$and\\b",
           "captures": {
             "0": {
-              "name": "keyword.and.mongodb"
+              "name": "keyword.other.QueryOperators.and.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$all\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.QueryOperators.all.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$zip\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.zip.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$year\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.year.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$week\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.week.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$type\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.type.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$trunc\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.trunc.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$toUpper\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.toUpper.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$toLower\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.toLower.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$switch\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.switch.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$subtract\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.subtract.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$substrCP\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.substrCP.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$substrBytes\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.substrBytes.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$substr\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.substr.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$strLenCP\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.strLenCP.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$strLenBytes\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.strLenBytes.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$strcasecmp\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.strcasecmp.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$sqrt\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.sqrt.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$split\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.split.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$slice\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.slice.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$size\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.size.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$setUnion\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.setUnion.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$setIsSubset\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.setIsSubset.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$setIntersection\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.setIntersection.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$setEquals\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.setEquals.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$setDifference\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.setDifference.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$second\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.second.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$reverseArray\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.reverseArray.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$reduce\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.reduce.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$range\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.range.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$pow\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.pow.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$or\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.or.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$objectToArray\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.objectToArray.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$not\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.not.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$new\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.new.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$multiply\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.multiply.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$month\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.month.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$mod\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.mod.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$minute\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.minute.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$millisecond\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.millisecond.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$meta\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.meta.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$mergeObjects\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.mergeObjects.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$map\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.map.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$log10\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.log10.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$log\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.log.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$ln\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.ln.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$lt\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.lt.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$literal\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.literal.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$let\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.let.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$isoWeekYear\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.isoWeekYear.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$isoWeek\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.isoWeek.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$isoDayOfWeek\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.isoDayOfWeek.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$isArray\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.isArray.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$indexOfCP\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.indexOfCP.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$indexOfBytes\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.indexOfBytes.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$indexOfArray\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.indexOfArray.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$in\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.in.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$ifNull\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.ifNull.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$hour\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.hour.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$gte\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.gte.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$gt\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.gt.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$floor\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.floor.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$filter\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.filter.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$exp\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.exp.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$eq\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.eq.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$divide\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.divide.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$dayOfYear\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.dayOfYear.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$dayOfWeek\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.dayOfWeek.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$dayOfMonth\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.dayOfMonth.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$dateToString\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.dateToString.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$dateToParts\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.dateToParts.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$dateFromString\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.dateFromString.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$dateFromParts\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.dateFromParts.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$cond\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.cond.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$concatArrays\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.concatArrays.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$concat\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.concat.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$cmp\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.cmp.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$ceil\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.ceil.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$arrayToObject\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.arrayToObject.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$arrayElemAt\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.arrayElemAt.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$anyElementTrue\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.anyElementTrue.mongodb"
+            }
+          }
+        },
+        {
+          "name": "meta.object.member.mongodb",
+          "match": "\\$and\\b",
+          "captures": {
+            "0": {
+              "name": "keyword.other.aggExpressionOperators.and.mongodb"
             }
           }
         },
@@ -3771,7 +3888,7 @@
           "match": "\\$allElementsTrue\\b",
           "captures": {
             "0": {
-              "name": "keyword.allElementsTrue.mongodb"
+              "name": "keyword.other.aggExpressionOperators.allElementsTrue.mongodb"
             }
           }
         },
@@ -3780,7 +3897,7 @@
           "match": "\\$add\\b",
           "captures": {
             "0": {
-              "name": "keyword.add.mongodb"
+              "name": "keyword.other.aggExpressionOperators.add.mongodb"
             }
           }
         },
@@ -3789,7 +3906,7 @@
           "match": "\\$abs\\b",
           "captures": {
             "0": {
-              "name": "keyword.abs.mongodb"
+              "name": "keyword.other.aggExpressionOperators.abs.mongodb"
             }
           }
         },
@@ -3798,7 +3915,7 @@
           "match": "\\$trim\\b",
           "captures": {
             "0": {
-              "name": "keyword.trim.mongodb"
+              "name": "keyword.other.aggConverters.trim.mongodb"
             }
           }
         },
@@ -3807,7 +3924,7 @@
           "match": "\\$toString\\b",
           "captures": {
             "0": {
-              "name": "keyword.toString.mongodb"
+              "name": "keyword.other.aggConverters.toString.mongodb"
             }
           }
         },
@@ -3816,7 +3933,7 @@
           "match": "\\$toObjectId\\b",
           "captures": {
             "0": {
-              "name": "keyword.toObjectId.mongodb"
+              "name": "keyword.other.aggConverters.toObjectId.mongodb"
             }
           }
         },
@@ -3825,7 +3942,7 @@
           "match": "\\$toLong\\b",
           "captures": {
             "0": {
-              "name": "keyword.toLong.mongodb"
+              "name": "keyword.other.aggConverters.toLong.mongodb"
             }
           }
         },
@@ -3834,7 +3951,7 @@
           "match": "\\$toInt\\b",
           "captures": {
             "0": {
-              "name": "keyword.toInt.mongodb"
+              "name": "keyword.other.aggConverters.toInt.mongodb"
             }
           }
         },
@@ -3843,7 +3960,7 @@
           "match": "\\$toDouble\\b",
           "captures": {
             "0": {
-              "name": "keyword.toDouble.mongodb"
+              "name": "keyword.other.aggConverters.toDouble.mongodb"
             }
           }
         },
@@ -3852,7 +3969,7 @@
           "match": "\\$toDecimal\\b",
           "captures": {
             "0": {
-              "name": "keyword.toDecimal.mongodb"
+              "name": "keyword.other.aggConverters.toDecimal.mongodb"
             }
           }
         },
@@ -3861,7 +3978,7 @@
           "match": "\\$toDate\\b",
           "captures": {
             "0": {
-              "name": "keyword.toDate.mongodb"
+              "name": "keyword.other.aggConverters.toDate.mongodb"
             }
           }
         },
@@ -3870,7 +3987,7 @@
           "match": "\\$toBool\\b",
           "captures": {
             "0": {
-              "name": "keyword.toBool.mongodb"
+              "name": "keyword.other.aggConverters.toBool.mongodb"
             }
           }
         },
@@ -3879,7 +3996,7 @@
           "match": "\\$rtrim\\b",
           "captures": {
             "0": {
-              "name": "keyword.rtrim.mongodb"
+              "name": "keyword.other.aggConverters.rtrim.mongodb"
             }
           }
         },
@@ -3888,7 +4005,7 @@
           "match": "\\$ltrim\\b",
           "captures": {
             "0": {
-              "name": "keyword.ltrim.mongodb"
+              "name": "keyword.other.aggConverters.ltrim.mongodb"
             }
           }
         },
@@ -3897,7 +4014,7 @@
           "match": "\\$convert\\b",
           "captures": {
             "0": {
-              "name": "keyword.convert.mongodb"
+              "name": "keyword.other.aggConverters.convert.mongodb"
             }
           }
         },
@@ -3906,7 +4023,7 @@
           "match": "\\$sum\\b",
           "captures": {
             "0": {
-              "name": "keyword.sum.mongodb"
+              "name": "keyword.other.aggAccumulators.sum.mongodb"
             }
           }
         },
@@ -3915,7 +4032,7 @@
           "match": "\\$stdDevSamp\\b",
           "captures": {
             "0": {
-              "name": "keyword.stdDevSamp.mongodb"
+              "name": "keyword.other.aggAccumulators.stdDevSamp.mongodb"
             }
           }
         },
@@ -3924,7 +4041,7 @@
           "match": "\\$stdDevPop\\b",
           "captures": {
             "0": {
-              "name": "keyword.stdDevPop.mongodb"
+              "name": "keyword.other.aggAccumulators.stdDevPop.mongodb"
             }
           }
         },
@@ -3933,7 +4050,7 @@
           "match": "\\$push\\b",
           "captures": {
             "0": {
-              "name": "keyword.push.mongodb"
+              "name": "keyword.other.aggAccumulators.push.mongodb"
             }
           }
         },
@@ -3942,7 +4059,7 @@
           "match": "\\$min\\b",
           "captures": {
             "0": {
-              "name": "keyword.min.mongodb"
+              "name": "keyword.other.aggAccumulators.min.mongodb"
             }
           }
         },
@@ -3951,7 +4068,7 @@
           "match": "\\$max\\b",
           "captures": {
             "0": {
-              "name": "keyword.max.mongodb"
+              "name": "keyword.other.aggAccumulators.max.mongodb"
             }
           }
         },
@@ -3960,7 +4077,7 @@
           "match": "\\$last\\b",
           "captures": {
             "0": {
-              "name": "keyword.last.mongodb"
+              "name": "keyword.other.aggAccumulators.last.mongodb"
             }
           }
         },
@@ -3969,7 +4086,7 @@
           "match": "\\$first\\b",
           "captures": {
             "0": {
-              "name": "keyword.first.mongodb"
+              "name": "keyword.other.aggAccumulators.first.mongodb"
             }
           }
         },
@@ -3978,7 +4095,7 @@
           "match": "\\$avg\\b",
           "captures": {
             "0": {
-              "name": "keyword.avg.mongodb"
+              "name": "keyword.other.aggAccumulators.avg.mongodb"
             }
           }
         },
@@ -3987,7 +4104,7 @@
           "match": "\\$addToSet\\b",
           "captures": {
             "0": {
-              "name": "keyword.addToSet.mongodb"
+              "name": "keyword.other.aggAccumulators.addToSet.mongodb"
             }
           }
         },


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
* According to [the TextMate naming conventions](https://macromates.com/manual/en/language_grammars#naming-conventions) it is better to “spread out” naming i.e. instead of putting everything below keyword create different root groups. In our case, we can get rid of extra iterations over the `mongodbSymbols` array where we remove repeated keywords that appear in different groups of symbols.
* Add `keyword.other.*` prefix to MongoDB symbols. The TextMate naming conventions recommends 3 types of keywords and `other` group seems like a proper one for our needs:

  - `control` — mainly related to flow control like continue, while, return, etc.
  - `operator` — operators can either be textual (e.g. or) or be characters.
  - `other` — other keywords.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
